### PR TITLE
Create and Integrate Database Queries for Settings Management

### DIFF
--- a/src/components/DevTools/components/DevTools.tsx
+++ b/src/components/DevTools/components/DevTools.tsx
@@ -5,7 +5,10 @@ import {
   useLogoutMutation,
   useRegisterMutation,
 } from 'features/auth/authApi';
-import { useAddSensorDataMutation } from 'features/db/dbApi';
+import {
+  useAddSensorDataMutation,
+  useSetSettingsMutation,
+} from 'features/db/dbApi';
 import { tapX } from 'utility/fp/tapX';
 
 const REGISTRATION_DATA = {
@@ -29,6 +32,21 @@ const DevTools = () => {
   const [login, { isLoading: isLoginLoading }] = useLoginMutation();
   const [addDataMutation, { isLoading: isAddDataLoading }] =
     useAddSensorDataMutation();
+  const [setSettingsMutation, { isLoading: isSetSettingsLoading }] =
+    useSetSettingsMutation();
+
+  const setSettings = () =>
+    setSettingsMutation({
+      arduinoId: '1',
+      settings: {
+        led: randomNum(2),
+        fan: randomNum(2),
+        updateInterval: randomNum(100),
+        co2: { min: randomNum(100), max: randomNum(100) },
+        humidity: { min: randomNum(100), max: randomNum(100) },
+        temperature: { min: randomNum(100), max: randomNum(100) },
+      },
+    }).catch(tapX('set settings error'));
 
   const handleRegister = () =>
     register(REGISTRATION_DATA)
@@ -57,6 +75,7 @@ const DevTools = () => {
   return (
     <Box
       style={{
+        maxWidth: 260,
         zIndex: 9999,
         position: 'fixed',
         padding: 16,
@@ -91,10 +110,21 @@ const DevTools = () => {
           >
             Logout
           </Button>
+          <Button
+            size="compact-sm"
+            loading={isAddDataLoading}
+            onClick={addData}
+          >
+            Add Data
+          </Button>
+          <Button
+            size="compact-sm"
+            loading={isSetSettingsLoading}
+            onClick={setSettings}
+          >
+            Set Settings
+          </Button>
         </Group>
-        <Button size="compact-sm" loading={isAddDataLoading} onClick={addData}>
-          Add Sensor Data
-        </Button>
       </Stack>
     </Box>
   );

--- a/src/features/Settings/Settings.tsx
+++ b/src/features/Settings/Settings.tsx
@@ -1,9 +1,16 @@
 import { Container, Title } from '@mantine/core';
 
+import { useGetSettingsQuery } from 'features/db/dbApi';
+
+const ARDUINO_ID = '1';
+
 export const Settings = () => {
+  const { data } = useGetSettingsQuery(ARDUINO_ID);
+
   return (
     <Container size="xl">
       <Title>Settings Page</Title>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
     </Container>
   );
 };

--- a/src/features/db/DbService.ts
+++ b/src/features/db/DbService.ts
@@ -31,6 +31,10 @@ export type GetUserDetailsResponse = User | undefined;
 export type GetUserDetailsArg = string;
 export type SetUserDetailsArg = Partial<User> & { uid: string };
 export type SetUserDetailsResponse = void;
+export type GetSettingsResponse = Settings | undefined;
+export type GetSettingsArg = string;
+export type SetSettingsResponse = void;
+export type SetSettingsArg = { arduinoId: string; settings: Settings };
 
 export type SensorData = {
   arduino: number;
@@ -42,6 +46,16 @@ export type SensorData = {
 export type SensorDataWithDate = Omit<SensorData, 'date'> & { date: Date };
 type SensorDataWithTimestamp = Omit<SensorData, 'date'> & {
   date: Timestamp;
+};
+
+type SensorSettings = { min: number; max: number };
+export type Settings = {
+  led: number;
+  fan: number;
+  updateInterval: number;
+  co2: SensorSettings;
+  humidity: SensorSettings;
+  temperature: SensorSettings;
 };
 
 type RootCollection = 'users' | 'settings' | 'sensors';
@@ -148,4 +162,25 @@ export class DbService {
     const collRef = this.#getCollRef('sensors');
     return addDoc(collRef, data);
   }
+
+  /**
+   * Get settings for a given Arduino ID.
+   * @param arduinoId The Arduino ID to get settings for.
+   * @returns A promise that resolves with the settings object.
+   */
+  getSettings = (arduinoId: string) => {
+    const settingsDocRef = this.#getDocRef(`settings/${arduinoId}`);
+    return getDoc(settingsDocRef).then(getSnapshotData<Settings>);
+  };
+
+  /**
+   * Set settings for a given Arduino ID.
+   * @param arduinoId The Arduino ID to set settings for.
+   * @param settings The settings object to set.
+   * @returns A promise that resolves when the settings are set.
+   */
+  setSettings = ({ arduinoId, settings }: SetSettingsArg) => {
+    const settingsDocRef = this.#getDocRef(`settings/${arduinoId}`);
+    return setDoc(settingsDocRef, settings);
+  };
 }

--- a/src/features/db/dbApi.ts
+++ b/src/features/db/dbApi.ts
@@ -3,10 +3,14 @@ import type { Unsubscribe } from 'firebase/firestore';
 
 import {
   DbService,
+  GetSettingsArg,
+  GetSettingsResponse,
   GetUserDetailsArg,
   GetUserDetailsResponse,
   SensorData,
   SensorDataWithDate,
+  SetSettingsArg,
+  SetSettingsResponse,
   SetUserDetailsArg,
   SetUserDetailsResponse,
 } from 'features/db/DbService';
@@ -17,6 +21,7 @@ const formatError = <T>(data: T) => ({ error: jsonSafeParse(data) });
 
 const dbTags = {
   UserDetails: 'UserDetails',
+  Settings: 'Settings',
 };
 
 export const dbApi = createApi({
@@ -36,18 +41,18 @@ export const dbApi = createApi({
     setUserDetails: builder.mutation<SetUserDetailsResponse, SetUserDetailsArg>(
       {
         invalidatesTags: [dbTags.UserDetails],
-        queryFn: (user) =>
+        queryFn: (queryArg) =>
           DbService.getInstance()
-            .setUserDetails(user)
+            .setUserDetails(queryArg)
             .then(formatData)
             .catch(formatError),
       },
     ),
 
     addSensorData: builder.mutation<SensorData, SensorDataWithDate>({
-      queryFn: (data) =>
+      queryFn: (queryArg) =>
         DbService.getInstance()
-          .addSensorData(data)
+          .addSensorData(queryArg)
           .then(formatData)
           .catch(formatError),
     }),
@@ -77,6 +82,24 @@ export const dbApi = createApi({
         unsubscribe?.();
       },
     }),
+
+    getSettings: builder.query<GetSettingsResponse, GetSettingsArg>({
+      providesTags: [dbTags.Settings],
+      queryFn: (queryArg) =>
+        DbService.getInstance()
+          .getSettings(queryArg)
+          .then(formatData)
+          .catch(formatError),
+    }),
+
+    setSettings: builder.mutation<SetSettingsResponse, SetSettingsArg>({
+      invalidatesTags: [dbTags.Settings],
+      queryFn: (queryArg) =>
+        DbService.getInstance()
+          .setSettings(queryArg)
+          .then(formatData)
+          .catch(formatError),
+    }),
   }),
 });
 
@@ -85,6 +108,8 @@ export const {
   useSetUserDetailsMutation,
   useAddSensorDataMutation,
   useGetSensorDataQuery,
+  useGetSettingsQuery,
+  useSetSettingsMutation,
 } = dbApi;
 
 export const useLazyGetUserDetailsQuerySubscription =


### PR DESCRIPTION
This pull request adds the necessary database queries and mutations for retrieving and saving application settings. It also integrates these queries and mutations with the existing database service to ensure seamless data flow and synchronization with the settings page. Fixes #48.